### PR TITLE
URIs for death registrations

### DIFF
--- a/v1/examples/life-events/death-registration-update.json
+++ b/v1/examples/life-events/death-registration-update.json
@@ -67,7 +67,7 @@
           }
         ]
       },
-      "deathRegistrationID": 123456,
+      "deathRegistration": "urn:fdc:gro.gov.uk:2023:123456",
       "deathDate": {
         "value": "1989-07",
         "description": "Deceased found on 3 August 1989"

--- a/v1/examples/life-events/death-registration.json
+++ b/v1/examples/life-events/death-registration.json
@@ -67,7 +67,7 @@
           }
         ]
       },
-      "deathRegistrationID": 123456,
+      "deathRegistration": "urn:fdc:gro.gov.uk:2023:123456",
       "deathDate": {
         "value": "1989-07",
         "description": "Deceased found on 3 August 1989"

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -47,7 +47,7 @@ classes:
       subject:
         range: DeathRegistrationSubjectClass
     slots:
-      - deathRegistrationID
+      - deathRegistration
       - deathDate
       - freeFormatDeathDate
       - deathRegistrationTime
@@ -56,7 +56,7 @@ classes:
       subject:
         range: DeathRegistrationSubjectClass
     slots:
-      - deathRegistrationID
+      - deathRegistration
       - deathDate
       - freeFormatDeathDate
       - recordUpdateTime
@@ -76,9 +76,10 @@ slots:
     slot_uri: schema:deathDate
   freeFormatDeathDate:
     description: Free format date of death of deceased person.
-  deathRegistrationID:
-    description: Registration ID on the RON system
-    range: integer
+  deathRegistration:
+    description: URI for the death notification, likely to be a <a href="https://www.rfc-editor.org/rfc/rfc4198.html">federated content URN</a> based on an originator's identifier
+    range: uri
+    required: true
   deathRegistrationTime:
     description: Date/time the death was registered, may be the same as the `toe` JWT claim
     range: StructuredDateTimeClass


### PR DESCRIPTION
Use URIs (specifically, federated content URNs) for death registration record identifiers

- avoids any possibility of clashes when we use a new source of death notifications
- allows for arbitrary strings rather than just integer identifiers, tho potentially subject to escaping
- see https://www.rfc-editor.org/rfc/rfc4198.html for restrictions
- name of property changed to use JSON-LD practice of allowing the value of the thing to be a reference
- which also maybe makes it more clear that a transformation must occur