### PR TITLE
Add property for 'free format' birth date

### DIFF
--- a/v1/examples/life-events/death-registered.json
+++ b/v1/examples/life-events/death-registered.json
@@ -56,6 +56,7 @@
             "value": "1989-07-06"
           }
         ],
+        "freeFormatBirthDate": "Some time between July 1989 and February 1990",
         "address": [
           {
             "subBuildingName": "Flat 4",

--- a/v1/examples/life-events/death-registration-updated.json
+++ b/v1/examples/life-events/death-registration-updated.json
@@ -56,6 +56,7 @@
             "value": "1989-07-06"
           }
         ],
+        "freeFormatBirthDate": "Some time between July 1989 and February 1990",
         "address": [
           {
             "subBuildingName": "Flat 4",

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -69,15 +69,19 @@ classes:
         slot_uri: schema:birthDate
         multivalued: true
         inlined_as_list: true
+    slots:
+      - freeFormatBirthDate
 
 slots:
   deathDate:
     range: ISODateClass
     slot_uri: schema:deathDate
+  freeFormatBirthDate:
+    description: Free format date of birth, used where the birth date could not be expressed as a partial or complete ISO date.
   freeFormatDeathDate:
-    description: Free format date of death of deceased person.
+    description: Free format date of death, used where the death date could not be expressed as a partial or complete ISO date.
   deathRegistration:
-    description: URI for the relevant entry in the register of deaths, likely to be a <a href="https://www.rfc-editor.org/rfc/rfc4198.html">federated content URN</a> based on an originator's identifier
+    description: URI for the relevant entry in the register of deaths, likely to be a <a href="https://www.rfc-editor.org/rfc/rfc4198.html">federated content URN</a> based on an originator's identifier.
     range: uri
     required: true
   deathRegistrationTime:

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -77,9 +77,9 @@ slots:
     range: ISODateClass
     slot_uri: schema:deathDate
   freeFormatBirthDate:
-    description: Free format date of birth, used where the birth date could not be expressed as a partial or complete ISO date.
+    description: A string containing free format birth date information, used where the birth date could not be expressed as a partial or complete ISO date. This property is expected to be present if `birthDate` is not present, but could be used alongside `birthDate` in some cases.
   freeFormatDeathDate:
-    description: Free format date of death, used where the death date could not be expressed as a partial or complete ISO date.
+    description: A string containing free format death date information, used where the death date could not be expressed as a partial or complete ISO date. This property is expected to be present if `deathDate` is not present, but could be used alongside `deathDate` in some cases.
   deathRegistration:
     description: URI for the relevant entry in the register of deaths, likely to be a <a href="https://www.rfc-editor.org/rfc/rfc4198.html">federated content URN</a> based on an originator's identifier.
     range: uri


### PR DESCRIPTION
- As a 'free format' field could contain anything, there's no reason for there to be more than one value.
- Also seems unlikely there could be additional metadata about data in this field given its loose definition.
- This field is very particular to a general register, probably nobody else is going to use it.
- Internal consistency with 'freeFormatDeathDate' seems more important than making this a structured attribute or even a list of structured attributes.
- So no 'object with value' structure, just a string property on the subject.