### PR TITLE
Avoid future register entry URI clashes

### DIFF
--- a/v1/examples/life-events/death-registered.json
+++ b/v1/examples/life-events/death-registered.json
@@ -68,7 +68,7 @@
           }
         ]
       },
-      "deathRegistration": "urn:fdc:gro.gov.uk:2023:123456",
+      "deathRegistration": "urn:fdc:gro.gov.uk:2023:death:123456",
       "deathDate": {
         "value": "1989-07",
         "description": "Deceased found on 3 August 1989"

--- a/v1/examples/life-events/death-registration-updated.json
+++ b/v1/examples/life-events/death-registration-updated.json
@@ -68,7 +68,7 @@
           }
         ]
       },
-      "deathRegistration": "urn:fdc:gro.gov.uk:2023:123456",
+      "deathRegistration": "urn:fdc:gro.gov.uk:2023:death:123456",
       "deathDate": {
         "value": "1989-07",
         "description": "Deceased found on 3 August 1989"

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -81,9 +81,11 @@ slots:
   freeFormatDeathDate:
     description: A string containing free format death date information, used where the death date could not be expressed as a partial or complete ISO date. This property is expected to be present if `deathDate` is not present, but could be used alongside `deathDate` in some cases.
   deathRegistration:
-    description: URI for the relevant entry in the register of deaths, likely to be a <a href="https://www.rfc-editor.org/rfc/rfc4198.html">federated content URN</a> based on an originator's identifier.
+    description: URI for the relevant entry in the register of deaths, likely to be a <a href="https://www.rfc-editor.org/rfc/rfc4198.html">federated content URN</a> based on an originator's identifier. The regular expression validation pattern provided applies only for the Life Events Platform proof of concept and will be removed in future.
     range: uri
     required: true
+    pattern: "urn:fdc:gro.gov.uk:2023:death:[0-9]+"
+
   deathRegistrationTime:
     description: Date/time the death was registered, may be the same as the `toe` JWT claim
     range: datetime


### PR DESCRIPTION
Add 'death' to part of the FDC URN we're planning to use for death registrations

- otherwise we would have clashing URIs if we want to model other GRO events like births and marriages
- add a regular expression to check the data is correct (only valid for the POC, we'll remove it at some point)
- update the examples to match