### PR TITLE
Time zones for events

### DIFF
--- a/v1/examples/life-events/death-registered.json
+++ b/v1/examples/life-events/death-registered.json
@@ -73,7 +73,7 @@
         "description": "Deceased found on 3 August 1989"
       },
       "freeFormatDeathDate": "Unknown due to mortuary error but some time in July 1989",
-      "deathRegistrationTime": "1989-08-10T10:22:04"
+      "deathRegistrationTime": "1989-08-10T10:22:04Z"
     }
   }
 }

--- a/v1/examples/life-events/death-registered.json
+++ b/v1/examples/life-events/death-registered.json
@@ -2,7 +2,7 @@
   "iss": "https://life-events-platform.gov.uk.example",
   "iat": 1691637001,
   "jti": "4d3559ec67504aaba65d40b0363faad8",
-  "toe": 618744124,
+  "toe": 618747724,
   "events": {
     "https://vocab.account.gov.uk/v1/deathRegistered": {
       "subject": {

--- a/v1/examples/life-events/death-registration-updated.json
+++ b/v1/examples/life-events/death-registration-updated.json
@@ -73,7 +73,7 @@
         "description": "Deceased found on 3 August 1989"
       },
       "freeFormatDeathDate": "Unknown due to mortuary error but some time in July 1989",
-      "recordUpdateTime": "1989-08-10T18:09:10",
+      "recordUpdateTime": "1989-08-10T18:09:10Z",
       "deathRegistrationUpdateReason": "formal_correction"
     }
   }

--- a/v1/examples/life-events/death-registration-updated.json
+++ b/v1/examples/life-events/death-registration-updated.json
@@ -2,7 +2,7 @@
   "iss": "https://life-events-platform.gov.uk.example",
   "iat": 1691637001,
   "jti": "4d3559ec67504aaba65d40b0363faad8",
-  "toe": 618772150,
+  "toe": 618775750,
   "events": {
     "https://vocab.account.gov.uk/v1/deathRegistrationUpdated": {
       "subject": {

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -81,10 +81,10 @@ slots:
     range: uri
     required: true
   deathRegistrationTime:
-    description: Date/time the death was registered, may be the same as the `toe` JWT claim
+    description: Date/time the death was registered, must include a time zone specifier which should be UTC. For deathRegistered events, the `toe` JWT claim must correspond to this value.
     range: datetime
   recordUpdateTime:
-    description: Date/time the record was amended, may be the same as the `toe` JWT claim
+    description: Date/time the record was amended, must include a time zone specifier which should be UTC. For deathRegistrationUpdated events, the `toe` JWT claim must correspond to this value.
     range: datetime
   deathRegistrationUpdateReason:
     description: A code noting the reason for the update to the death record


### PR DESCRIPTION
Follow on from https://github.com/alphagov/di-identity-vocab/pull/46

Specify that times zones are mandatory and should be UTC

there doesn't seem to be an easy way of enforcing this in JSON Schema
we might look into writing/finding a regex I suppose

Also fix the `toe` values to be correct per our spec.