### PR TITLE
Fix death event in line with RFC

### DIFF
--- a/v1/linkml-schemas/common.yaml
+++ b/v1/linkml-schemas/common.yaml
@@ -32,6 +32,7 @@ classes:
       - value
 
   ISODateClass:
+    description: Contains a complete or partial ISO date, with no time part and in which the day and month parts are optional.
     is_a: StructuredAttributeClass
     slots:
       - description
@@ -39,6 +40,7 @@ classes:
       value:
         pattern: "^\\d{4}(?:-\\d{2}(?:-\\d{2})?)?$"
         range: string
+        description: The date in the form CCYY[-MM[-DD]]
 
 types:
   JWS:

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -77,6 +77,7 @@ slots:
   deathDate:
     range: ISODateClass
     slot_uri: schema:deathDate
+    description: An object containing details of a person's death date.
   freeFormatBirthDate:
     description: A string containing free format birth date information, used where the birth date could not be expressed as a partial or complete ISO date. This property is expected to be present if `birthDate` is not present, but could be used alongside `birthDate` in some cases.
   freeFormatDeathDate:

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -46,20 +46,16 @@ classes:
     attributes:
       subject:
         range: DeathRegistrationSubjectClass
+        required: true
+        description: An object containing details of a person that has died for matching against existing records.
     slots:
       - deathRegistration
       - deathDate
       - freeFormatDeathDate
       - deathRegistrationTime
   DeathRegistrationUpdatedEventClass:
-    attributes:
-      subject:
-        range: DeathRegistrationSubjectClass
+    is_a: DeathRegisteredEventClass
     slots:
-      - deathRegistration
-      - deathDate
-      - freeFormatDeathDate
-      - deathRegistrationTime
       - recordUpdateTime
       - deathRegistrationUpdateReason
   DeathRegistrationSubjectClass:

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -84,10 +84,10 @@ slots:
     required: true
     pattern: "urn:fdc:gro.gov.uk:2023:death:[0-9]+"
   deathRegistrationTime:
-    description: Date/time the death was registered, must include a time zone specifier which should be UTC. For deathRegistered events, the `toe` JWT claim must correspond to this value.
+    description: Date/time the death was registered, must include a time zone specifier which should be UTC. For deathRegistered events, we expect this property to be present, and the `toe` JWT claim must correspond to this value.
     range: datetime
   recordUpdateTime:
-    description: Date/time the record was amended, must include a time zone specifier which should be UTC. For deathRegistrationUpdated events, the `toe` JWT claim must correspond to this value.
+    description: Date/time the record was amended, must include a time zone specifier which should be UTC. For deathRegistrationUpdated events, we expect this property to be present, and the `toe` JWT claim must correspond to this value.
     range: datetime
   deathRegistrationUpdateReason:
     description: A code noting the reason for the update to the death record

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -59,6 +59,7 @@ classes:
       - deathRegistration
       - deathDate
       - freeFormatDeathDate
+      - deathRegistrationTime
       - recordUpdateTime
       - deathRegistrationUpdateReason
   DeathRegistrationSubjectClass:
@@ -85,7 +86,6 @@ slots:
     range: uri
     required: true
     pattern: "urn:fdc:gro.gov.uk:2023:death:[0-9]+"
-
   deathRegistrationTime:
     description: Date/time the death was registered, must include a time zone specifier which should be UTC. For deathRegistered events, the `toe` JWT claim must correspond to this value.
     range: datetime


### PR DESCRIPTION
The main purpose of this change is to bring the schema more line with [RFC 56](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0056-physical-data-model-death-notification-event.md).

`deathRegistrationTime` is allowed for 'death registration updated' events, even though we don't expect HMPO/GRO to be populating that.

That field remains (like most of the others) optional, to keep options open for variation in the shape of events that may come from other sources like NRS or GRONI.

However a substantive change is to require `subject` because it seems unlikely that such an event would be useful without that.

Also refactored for DRY reasons.