### PR TITLE
build: fix submodule paths.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "mkdocs-govuk"]
 	path = mkdocs-govuk
-	url = ../mkdocs-govuk.git
+	url = ../../alphagov/mkdocs-govuk.git
 	branch = nav_menu_no_root_links
 [submodule "linkml"]
 	path = linkml
-	url = ../linkml.git
+	url = ../../alphagov/linkml.git
 	branch = generate-site-to-dirs


### PR DESCRIPTION
Since the repo has moved from the `alphagov` org, we need to fix the submodule paths.