### PR TITLE
build: fix broken Node.js module publishing due to org change.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@alphagov'
+          scope: '@govuk-one-login'
 
       - name: Download JSON Schemas
         uses: actions/download-artifact@v3

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This specification intends to describe a Linked Data vocabulary for asserting Ve
 
 This repository produces the following artifacts:
 
-* [Vocabulary documentation](https://alphagov.github.io/di-identity-vocab/)
-* [JSON Schemas](https://github.com/alphagov/di-identity-vocab/releases)
-* [TypeScript types (npm module)](https://github.com/alphagov/di-identity-vocab/pkgs/npm/di-identity-vocab)
+* [Vocabulary documentation](https://govuk-one-login.github.io/data-vocab/)
+* [JSON Schemas](https://github.com/govuk-one-login/data-vocab/releases)
+* [TypeScript types (npm module)](https://github.com/govuk-one-login/data-vocab/pkgs/npm/di-identity-vocab)
 
 Further development could include:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GOV.UK One Login Vocabulary
-repo_url: https://github.com/alphagov/di-identity-vocab
+repo_url: https://github.com/govuk-one-login/data-vocab
 theme:
     name: null
     custom_dir: 'mkdocs-govuk/govuk_theme'

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alphagov/di-identity-vocab.git"
+    "url": "git+https://github.com/govuk-one-login/data-vocab.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/alphagov/di-identity-vocab/issues"
+    "url": "https://github.com/govuk-one-login/data-vocab/issues"
   },
-  "homepage": "https://github.com/alphagov/di-identity-vocab#readme",
+  "homepage": "https://github.com/govuk-one-login/data-vocab#readme",
   "browser": {
     "assert": false
   },

--- a/src/package-template.json
+++ b/src/package-template.json
@@ -1,10 +1,10 @@
 {
-  "name": "@alphagov/di-identity-vocab",
+  "name": "@govuk-one-login/data-vocab",
   "description": "GOV.UK One Login - Digital Identity Vocabulary",
   "version": "0.1.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alphagov/di-identity-vocab"
+    "url": "https://github.com/govuk-one-login/data-vocab"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"


### PR DESCRIPTION
Following on from #58, the org name change also broke Node.js package publishing, as well as various links to the repo.