### PR TITLE
Remove schema files from home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,18 +18,7 @@ This vocabulary covers a number of use cases in the GOV.UK One Login domain, inc
 
 In future it may be extended to cover security events.
 
-## Schemas
-
-* [IdentityCheckCredential](v1/json-schemas/IdentityCheckCredential.json)
-* [IdentityCheckCredentialJWT](v1/json-schemas/IdentityCheckCredentialJWT.json)
-* [CoreIdentityJWT](v1/json-schemas/CoreIdentityJWT.json)
-* [OpenIDConnectAuthenticationRequest](v1/json-schemas/OpenIDConnectAuthenticationRequest.json)
-* [IssuerAuthorizationRequest](v1/json-schemas/IssuerAuthorizationRequest.json)
-* [Name](v1/json-schemas/Name.json)
-* [PostalAddress](v1/json-schemas/PostalAddress.json)
-* [DrivingPermit](v1/json-schemas/DrivingPermit.json)
-* [Passport](v1/json-schemas/PassportDetails.json)
-* [ResidencePermit](v1/json-schemas/ResidencePermit.json)
+We provide [JSON Schemas](./v1/json-schemas/) for many of the important classes in the vocabulary.
 
 ## Examples
 

--- a/scripts/check_schema_see_also.py
+++ b/scripts/check_schema_see_also.py
@@ -1,0 +1,25 @@
+import yaml
+import argparse
+import sys
+
+
+parser = argparse.ArgumentParser(
+    description='Check that the specified LinkML class definition includes a link to the provided JSON Schema file.'
+)
+parser.add_argument('linkml_schema_file')
+parser.add_argument('class_name')
+parser.add_argument('json_schema_file')
+args = parser.parse_args()
+
+# Attempting to automatically write these as 'see_also' links was much harder than it looked!
+
+with open(args.linkml_schema_file) as f:
+    y = yaml.safe_load(f)
+    related_refs = y['classes'][args.class_name].get('see_also', list())
+    if args.json_schema_file not in related_refs:
+        print(f"Missing 'see_also' reference to '{args.json_schema_file}' in {args.linkml_schema_file}/{args.class_name}", file=sys.stderr)
+        sys.exit(1)
+    description = y['classes'][args.class_name].get('description', '')
+    if f"]({args.json_schema_file}" not in description:
+        print(f"Missing reference to '{args.json_schema_file}' in description for {args.linkml_schema_file}/{args.class_name}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/generate_json_schemas.sh
+++ b/scripts/generate_json_schemas.sh
@@ -11,22 +11,22 @@ set -e
 
 # format: <linkml schema file>,<linkml class>,<json schema file>
 LINKML_ITEMS=(
-  "credentials.yaml,CoreIdentityJWTClass,CoreIdentityJWT.json"
-  "credentials.yaml,IdentityCheckCredentialJWTClass,IdentityCheckCredentialJWT.json"
-  "identityCheckCredential.yaml,IdentityCheckCredentialClass,IdentityCheckCredential.json"
   "credentials.yaml,AuthorizationRequestClass,AuthorizationRequest.json"
-  "securityCheckCredential.yaml,SecurityCheckCredentialClass,SecurityCheckCredential.json"
-  "address.yaml,PostalAddressClass,PostalAddress.json"
-  "document.yaml,PassportDetailsClass,PassportDetails.json"
-  "document.yaml,DrivingPermitDetailsClass,DrivingPermit.json"
-  "document.yaml,ResidencePermitDetailsClass,ResidencePermit.json"
-  "document.yaml,SocialSecurityRecordDetailsClass,SocialSecurityRecord.json"
-  "document.yaml,IdCardDetailsClass,IdCard.json"
-  "name.yaml,NameClass,Name.json"
-  "credentials.yaml,IssuerAuthorizationRequestClass,IssuerAuthorizationRequest.json"
-  "credentials.yaml,OpenIDConnectAuthenticationRequestClass,OpenIDConnectAuthenticationRequest.json"
+  "credentials.yaml,CoreIdentityJWTClass,CoreIdentityJWT.json"
   "lifeEvents.yaml,DeathRegisteredJWTClass,DeathRegisteredJWT.json",
   "lifeEvents.yaml,DeathRegistrationUpdatedJWTClass,DeathRegistrationUpdatedJWT.json"
+  "document.yaml,DrivingPermitDetailsClass,DrivingPermit.json"
+  "document.yaml,IdCardDetailsClass,IdCard.json"
+  "identityCheckCredential.yaml,IdentityCheckCredentialClass,IdentityCheckCredential.json"
+  "credentials.yaml,IdentityCheckCredentialJWTClass,IdentityCheckCredentialJWT.json"
+  "credentials.yaml,IssuerAuthorizationRequestClass,IssuerAuthorizationRequest.json"
+  "name.yaml,NameClass,Name.json"
+  "credentials.yaml,OpenIDConnectAuthenticationRequestClass,OpenIDConnectAuthenticationRequest.json"
+  "document.yaml,PassportDetailsClass,PassportDetails.json"
+  "address.yaml,PostalAddressClass,PostalAddress.json"
+  "document.yaml,ResidencePermitDetailsClass,ResidencePermit.json"
+  "securityCheckCredential.yaml,SecurityCheckCredentialClass,SecurityCheckCredential.json"
+  "document.yaml,SocialSecurityRecordDetailsClass,SocialSecurityRecord.json"
 )
 
 ROOT_DIR="$( git rev-parse --show-toplevel )"

--- a/scripts/generate_json_schemas.sh
+++ b/scripts/generate_json_schemas.sh
@@ -13,9 +13,9 @@ set -e
 LINKML_ITEMS=(
   "credentials.yaml,CoreIdentityJWTClass,CoreIdentityJWT.json"
   "credentials.yaml,IdentityCheckCredentialJWTClass,IdentityCheckCredentialJWT.json"
-  "credentials.yaml,IdentityCheckCredentialClass,IdentityCheckCredential.json"
+  "identityCheckCredential.yaml,IdentityCheckCredentialClass,IdentityCheckCredential.json"
   "credentials.yaml,AuthorizationRequestClass,AuthorizationRequest.json"
-  "credentials.yaml,SecurityCheckCredentialClass,SecurityCheckCredential.json"
+  "securityCheckCredential.yaml,SecurityCheckCredentialClass,SecurityCheckCredential.json"
   "address.yaml,PostalAddressClass,PostalAddress.json"
   "document.yaml,PassportDetailsClass,PassportDetails.json"
   "document.yaml,DrivingPermitDetailsClass,DrivingPermit.json"
@@ -35,6 +35,8 @@ LINKML_SCHEMA_DIR="${ROOT_DIR}/v1/linkml-schemas"
 
 rm -f "${JSON_SCHEMA_DIR}/*.json"
 
+cp $JSON_SCHEMA_DIR/index.md.template $JSON_SCHEMA_DIR/index.md
+
 for LINKML_ITEM in "${LINKML_ITEMS[@]}"; do
   ITEM_DETAILS=(${LINKML_ITEM//,/ })
   LINKML_SCHEMA="${ITEM_DETAILS[0]}"
@@ -44,4 +46,6 @@ for LINKML_ITEM in "${LINKML_ITEMS[@]}"; do
 
   poetry run gen-json-schema --closed --no-metadata -t "${LINKML_CLASS}" \
     "${LINKML_SCHEMA_DIR}/${LINKML_SCHEMA}" > "${JSON_SCHEMA_DIR}/${JSON_SCHEMA}"
+  echo "| [$JSON_SCHEMA]($JSON_SCHEMA) | [$LINKML_CLASS](../classes/$LINKML_CLASS) |" >> $JSON_SCHEMA_DIR/index.md
+  poetry run python ./scripts/check_schema_see_also.py  "${LINKML_SCHEMA_DIR}/${LINKML_SCHEMA}" $LINKML_CLASS ../json-schemas/$JSON_SCHEMA
 done

--- a/v1/json-schemas/.gitignore
+++ b/v1/json-schemas/.gitignore
@@ -1,1 +1,2 @@
 *.json
+index.md

--- a/v1/json-schemas/index.md.template
+++ b/v1/json-schemas/index.md.template
@@ -1,0 +1,6 @@
+# JSON Schema files
+
+The following JSON Schema files are available to use for validation.
+
+| JSON Schema File | Data model source documentation |
+| -- | -- |

--- a/v1/linkml-schemas/address.yaml
+++ b/v1/linkml-schemas/address.yaml
@@ -45,6 +45,8 @@ classes:
       </ul>
       <p>Close mapping&#58; [adb:Address](http://www.geoplace.co.uk/addressbase/schema/2.1/addressbase.xsd)</p>
       <p>Close mapping&#58; [schema:PostalAddress](https://schema.org/PostalAddress)</p>
+    see_also:
+      - ../json-schemas/PostalAddress.json
     mixins:
       - ValidityClass
     slots:

--- a/v1/linkml-schemas/credentials.yaml
+++ b/v1/linkml-schemas/credentials.yaml
@@ -25,7 +25,10 @@ default_range: string
 classes:
   AuthorizationRequestClass:
     is_a: JWTClass
-    description: An [Authorization Request compliant with OAuth 2.0 section 4.1.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.1).
+    description: |
+      An [Authorization Request compliant with OAuth 2.0 section 4.1.1](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.1).
+
+      JSON schema: [AuthorizationRequest.json](../json-schemas/AuthorizationRequest.json)
     slots:
       - response_type
       - scope
@@ -33,21 +36,33 @@ classes:
       - state
       - redirect_uri
       - nonce
+    see_also:
+      - ../json-schemas/AuthorizationRequest.json
 
   OpenIDConnectAuthenticationRequestClass:
     is_a: AuthorizationRequestClass
-    description: An [Authentication Request compliant with OpenID Connect 2.0 section 3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) with any extensions supported by GOV.UK One Login.
+    description: |
+      An [Authentication Request compliant with OpenID Connect 2.0 section 3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) with any extensions supported by GOV.UK One Login.
+
+      JSON schema: [OpenIDConnectAuthenticationRequest.json](../json-schemas/OpenIDConnectAuthenticationRequest.json)
     slots:
       - vtr
       - prompt
       - claims
+    see_also:
+      - ../json-schemas/OpenIDConnectAuthenticationRequest.json
 
   IssuerAuthorizationRequestClass:
     is_a: AuthorizationRequestClass
-    description: An Authorization Request that provides shared claims and other user/session data to GOV.UK One Login credential issuers.
+    description: |
+      An Authorization Request that provides shared claims and other user/session data to GOV.UK One Login credential issuers.
+
+      JSON schema: [IssuerAuthorizationRequest.json](../json-schemas/IssuerAuthorizationRequest.json)
     slots:
       - shared_claims
       - govuk_signin_journey_id
+    see_also:
+      - ../json-schemas/IssuerAuthorizationRequest.json
 
   CoreIdentityJWTClass:
     is_a: JWTClass
@@ -75,6 +90,8 @@ classes:
 
       JSON schema: [IdentityCheckCredentialJWT.json](../json-schemas/IdentityCheckCredentialJWT.json)
     is_a: JWTClass
+    see_also:
+      - ../json-schemas/IdentityCheckCredentialJWT.json
     attributes:
       vc:
         range: IdentityCheckCredentialClass

--- a/v1/linkml-schemas/document.yaml
+++ b/v1/linkml-schemas/document.yaml
@@ -54,6 +54,8 @@ classes:
     slot_usage:
       expiryDate: 
         required: true
+    see_also:
+      - ../json-schemas/PassportDetails.json
   DrivingPermitDetailsClass:
     description: The details of a driving license/permit as presented by Optical Character Recognition of the physical document or manually input by a user. 
       <p>JSON schema&#58; [di_vocab:DrivingPermit](../json-schemas/DrivingPermit.json)</p>  
@@ -85,6 +87,8 @@ classes:
     slot_usage:
       expiryDate: 
         required: true
+    see_also:
+      - ../json-schemas/DrivingPermit.json
   ResidencePermitDetailsClass:
     description: The details of a biometric residency permit as presented by reading the biometric chip data using near-field communication (NFC), reading the Machine Readable Zone (MRZ) or manually input by a user. 
       <p>JSON schema&#58; [di_vocab:ResidencePermit](../json-schemas/ResidencePermit.json)</p>  
@@ -105,6 +109,8 @@ classes:
     slot_usage:
       expiryDate: 
         required: true
+    see_also:
+      - ../json-schemas/ResidencePermit.json
   SocialSecurityRecordDetailsClass:
     description: The details of a social security record as input by a user. 
       <p>JSON schema&#58; [di_vocab:SocialSecurityRecord](../json-schemas/SocialSecurityRecord.json)</p> 
@@ -116,7 +122,9 @@ classes:
       </ul>
     is_a: DocumentDetailsClass
     slots:
-      - personalNumber 
+      - personalNumber
+    see_also:
+      - ../json-schemas/SocialSecurityRecord.json
   IdCardDetailsClass:
     description: The details of a National Identification Card as presented by a user for identity verification. 
       <p>JSON schema&#58; [di_vocab:IdCard](../json-schemas/IdCard.json)</p> 
@@ -129,7 +137,9 @@ classes:
     is_a: DocumentDetailsClass
     slots:
       - documentNumber
-      - icaoIssuerCode    
+      - icaoIssuerCode
+    see_also:
+      - ../json-schemas/IdCard.json
 slots:
   passport:
     range: PassportDetailsClass

--- a/v1/linkml-schemas/identityCheckCredential.yaml
+++ b/v1/linkml-schemas/identityCheckCredential.yaml
@@ -27,6 +27,8 @@ classes:
       A [VC](https://www.w3.org/TR/vc-data-model/) representing an identity check that contributes to identity confidence per UK government standards such as [Good Practice Guide (GPG) 45](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual).
 
       In GOV.UK One Login this VC is always [issued in JWT format](../IdentityCheckCredentialJWTClass).
+
+      JSON schema: [IdentityCheckCredential.json](../json-schemas/IdentityCheckCredential.json)
     see_also:
       - ../json-schemas/IdentityCheckCredential.json
     slots:

--- a/v1/linkml-schemas/lifeEvents.yaml
+++ b/v1/linkml-schemas/lifeEvents.yaml
@@ -25,10 +25,14 @@ classes:
       It must contain a ['death registered' event object](../DeathRegisteredEventClass).
 
       Note that when a registration entry is updated, a [different signal](../DeathRegistrationUpdatedJWTClass) is generated.
+
+      JSON Schema: [DeathRegisteredJWT](../json-schemas/DeathRegisteredJWT.json)
     attributes:
       events:
         range: DeathRegisteredEventMappingClass
         required: true
+    see_also:
+      - ../json-schemas/DeathRegisteredJWT.json
   DeathRegisteredEventMappingClass:
     attributes:
       "deathRegistered":
@@ -41,11 +45,15 @@ classes:
       It must contain a ['death registration updated' event object](../DeathRegistrationUpdatedEventClass).
 
       Note that when a death is first registered, a [different signal](../DeathRegisteredJWTClass) is generated.
+
+      JSON Schema: [DeathRegisteredJWT](../json-schemas/DeathRegistrationUpdatedJWT.json)
     is_a: SETClass
     attributes:
       events:
         range: DeathRegistrationUpdatedEventMappingClass
         required: true
+    see_also:
+      - ../json-schemas/DeathRegistrationUpdatedJWT.json
   DeathRegistrationUpdatedEventMappingClass:
     attributes:
       "deathRegistrationUpdate":

--- a/v1/linkml-schemas/name.yaml
+++ b/v1/linkml-schemas/name.yaml
@@ -47,7 +47,9 @@ classes:
     slots:
       - nameParts
       - description
-      
+    see_also:
+      - ../json-schemas/Name.json
+
   NamePartClass:
     description: Abstract class to define a name part value and name part type for an optional validity period.
     abstract: false  # has to be false otherwise JSON-Schema doesn't include it, and validation fails :(

--- a/v1/linkml-schemas/securityCheckCredential.yaml
+++ b/v1/linkml-schemas/securityCheckCredential.yaml
@@ -21,6 +21,8 @@ classes:
       A [VC](https://www.w3.org/TR/vc-data-model/) containing evidence pertaining to security checks performed about a GOV.UK One Login account.
 
       In GOV.UK One Login this VC is always [issued in JWT format](../SecurityCheckCredentialJWTClass).
+
+      JSON schema: [SecurityCheckCredential.json](../json-schemas/SecurityCheckCredential.json)
     attributes:
       evidence:
         range: SecurityCheckClass
@@ -29,4 +31,6 @@ classes:
       type:
         range: VerifiableCredentialType
         multivalued: true
+    see_also:
+      - ../json-schemas/SecurityCheckCredential.json
 


### PR DESCRIPTION
- JSON schemas are not the most user-friendly way into discovering the Vocabulary
- instead, generate an index file containing all of the JSON schemas that we build
- also, ensure they are linked to from each relevant class
- for now at least, link both in the description and with see_also, consistently

Fixes issue https://github.com/govuk-one-login/data-vocab/issues/42

<img width="805" alt="Screenshot of new JSON Schemas index page" src="https://github.com/govuk-one-login/data-vocab/assets/190828/5d6e3d3f-287a-4a86-b8c6-54ccb808dc0f">

