### PR TITLE
SPT-575:Update vocab schema to reflect new  field

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
           - issueNumber: v1/slots/issueNumber.md
           - issuer: v1/slots/issuer.md
           - IssuerAuthorizationRequestClass_scope: v1/slots/IssuerAuthorizationRequestClass_scope.md
+          - issuers: v1/slots/issuers.md
           - issuingCountry: v1/slots/issuingCountry.md
           - jti: v1/slots/jti.md
           - kbvQuality: v1/slots/kbvQuality.md

--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -50,6 +50,7 @@ classes:
     slots:
       - code
       - issuanceDate
+      - issuers
       - document
       - mitigation
       - incompleteMitigation
@@ -221,6 +222,11 @@ slots:
   issuanceDate:
     description: The date a contra-indicator was generated.
     range: date
+  issuers:
+    description: An array of cri issuers.
+    range: uri
+    multivalued: true
+    inlined_as_list: true
   document:
     description: The single string representation of a document that a contra-indicator was raised against.
   mitigation:


### PR DESCRIPTION
**What**

Update the vocab schema for SecurityCheck credentials to allow an optional new field issuers that is list of URIs/strings.

**Why**

Adds the new field issuers to security credential schema so that SPOT will accept the new value.