### PR TITLE
SPT-679 SPOT: Update vocab schema

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,10 @@
 		"ghcr.io/devcontainers/features/python:1": {},
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {}
 	},
-	"forwardPorts": ["8000:8000"],
-	"postCreateCommand": "poetry install && npm ci && npm install -g ajv-cli@5.0.0 ajv-formats@2.1.1 sass",
+	"forwardPorts": [
+		"8000:8000"
+	],
+	"postCreateCommand": "pip install linkml && poetry install && npm ci && npm install -g ajv-cli@5.0.0 ajv-formats@2.1.1 sass",
 	"containerEnv": {
 		"TZ": "UTC"
 	}

--- a/v1/linkml-schemas/vectorsOfTrust.yaml
+++ b/v1/linkml-schemas/vectorsOfTrust.yaml
@@ -10,7 +10,7 @@ imports:
   - linkml:types
   - ./common
 default_curi_maps:
-  - semweb_context  
+  - semweb_context
 default_prefix: di_vocab
 default_range: string
 
@@ -21,10 +21,13 @@ enums:
       P2:
       P3:
       P4:
+      PCL200:
+      PCL250:
 
 slots:
   vot:
     range: IdentityVectorOfTrust
+    description: The `vot` identifies the Vector Of Trust.
   vtm:
     range: uri
     description: The `vtm` identifies the Vector Trust Mark.


### PR DESCRIPTION
## What

Update the vocab schema to reflect the fact that the `vot` can be either `PCL200` or `PCL250`.

## Why

Currently, the `vot` is defined as an enum containing values `P1`, `P2`, `P3` and `P4`. This needs reflect that new values are permissible.

## Acceptance Criteria

The following acceptance criteria were not followed. This is due to issues with the currently implementation whereby the `IdentityVectorOfTrust` and the new enum would result in the type being `string`. The SPOT team looked into this and determined that the best course of action would be to add the `PCL200` or `PCL250` to the existing `IdentityVectorOfTrust`. However, later investigations may be carried out into the tooling to determine if this is possible in the future.

* A new enum is defined for inherited identities that allows the values  `PCL200` and `PCL250`.
* The existing `IdentityVectorOfTrust` is not modified and continues to allow only `P1`, `P2`, `P3` and `P4`.
* The definition of the `vot` field is updated to allow a value from the union of the two enums.