### PR TITLE
SPT-624 Updated schema to represent existing CRI data

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
           - checkDetails: v1/slots/checkDetails.md
           - checkMethod: v1/slots/checkMethod.md
           - ci: v1/slots/ci.md
+          - ciReasons: v1/slots/ciReasons.md
           - claims: v1/slots/claims.md
           - client_id: v1/slots/client_id.md
           - code: v1/slots/code.md
@@ -109,6 +110,7 @@ nav:
           - dependentAddressLocality: v1/slots/dependentAddressLocality.md
           - dependentStreetName: v1/slots/dependentStreetName.md
           - description: v1/slots/description.md
+          - deviceId: v1/slots/deviceId.md
           - document: v1/slots/document.md
           - documentNumber: v1/slots/documentNumber.md
           - documentType: v1/slots/documentType.md
@@ -173,6 +175,8 @@ nav:
           - PassportDetailsClass_expiryDate: v1/slots/PassportDetailsClass_expiryDate.md
           - personalNumber: v1/slots/personalNumber.md
           - photoVerificationProcessLevel: v1/slots/photoVerificationProcessLevel.md
+          - poBoxNumber: v1/slots/poBoxNumber.md
+          - postalAddressClass__id: v1/slots/postalAddressClass__id.md
           - postalCode: v1/slots/postalCode.md
           - prompt: v1/slots/prompt.md
           - redirect_uri: v1/slots/redirect_uri.md

--- a/v1/linkml-schemas/address.yaml
+++ b/v1/linkml-schemas/address.yaml
@@ -10,15 +10,15 @@ imports:
   - linkml:types
   - ./common
 default_curi_maps:
-  - semweb_context  
+  - semweb_context
 default_prefix: di_vocab
 default_range: string
 
 classes:
   PostalAddressClass:
     description: >-
-      A postal address associated with a user, returned by an Address Lookup API or by manual data input. 
-      <p>JSON schema&#58; [di_vocab:PostalAddress](../json-schemas/PostalAddress.json)</p>  
+      A postal address associated with a user, returned by an Address Lookup API or by manual data input.
+      <p>JSON schema&#58; [di_vocab:PostalAddress](../json-schemas/PostalAddress.json)</p>
       <p>Examples</p>
       <ul>
       <li>
@@ -49,6 +49,11 @@ classes:
       - ../json-schemas/PostalAddress.json
     mixins:
       - ValidityClass
+    attributes:
+      id:
+        close_mappings:
+          - schema:identifier
+        description: Indentification number for the third party addresses
     slots:
       - uprn
       - organisationName
@@ -63,6 +68,7 @@ classes:
       - addressLocality
       - postalCode
       - addressCountry
+      - poBoxNumber
     close_mappings:
       - schema:PostalAddress
       - adb:Address
@@ -80,10 +86,10 @@ slots:
   departmentName:
     close_mappings: adb:departmentName
     description: For some organisations, department name is indicated because mail is received by subdivisions of the main organisation at distinct delivery points. E.g. Organisation Name - ABC COMMUNICATIONS Department Name - MARKETING DEPARTMENT
-                 <p>Close mapping&#58; [adb:departmentName](http://www.geoplace.co.uk/addressbase/schema/2.1/addressbase.xsd)</p>  
+                 <p>Close mapping&#58; [adb:departmentName](http://www.geoplace.co.uk/addressbase/schema/2.1/addressbase.xsd)</p>
   subBuildingName:
     close_mappings: adb:subBuildingName
-    description: The sub-building name and/or number are identifiers for subdivisions of properties.  
+    description: The sub-building name and/or number are identifiers for subdivisions of properties.
                  E.g. Sub-building Name - FLAT 3 Building Name - POPLAR COURT Thoroughfare - LONDON ROAD NOTE - If the address is styled as 3 POPLAR COURT, all the text will be shown in the Building Name attribute and the Sub-building Name will be empty. The building number will be shown in this field when it contains a range, decimal or non-numeric character (see Building Number).
                  <p>Close mapping&#58; [adb:subBuildingName](http://www.geoplace.co.uk/addressbase/schema/2.1/addressbase.xsd)</p>
   buildingNumber:
@@ -96,7 +102,7 @@ slots:
                  <p>Close mapping&#58; [adb:buildingNumber](http://www.geoplace.co.uk/addressbase/schema/2.1/addressbase.xsd)</p>
   buildingName:
     close_mappings: adb:buildingName
-    description: The building name is a description applied to a single building or a 
+    description: The building name is a description applied to a single building or a
                  small group of buildings, such as Highfield House. This also includes those building
                  numbers that contain non-numeric characters, such as 44A. Some descriptive names,
                  when included with the rest of the address, are sufficient to identify the property
@@ -143,3 +149,8 @@ slots:
     close_mappings: schema:addressCountry
     description: The country. Provided as the two-letter ISO 3166-1 alpha-2 country code.
                  <p>Close mapping&#58; [schema:addressCountry](https://schema.org/addressCountry)</p>
+  poBoxNumber:
+    close_mappings:
+      - schema:postOfficeBoxNumber
+    description: The post office box number for PO box addresses.
+                <p>Close mapping&#58; [schema:postOfficeBoxNumber](https://schema.org/postOfficeBoxNumber)</p>"

--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -8,7 +8,7 @@ imports:
   - linkml:types
   - ./common
 default_curi_maps:
-  - semweb_context  
+  - semweb_context
 default_prefix: di_vocab
 default_range: string
 
@@ -66,8 +66,8 @@ classes:
       - issuer
       - validFrom
       - txn
-      - id 
-  
+      - id
+
   EvidenceRequestedClass:
     description: The levels of evidence_requested which are minimum GPG45 criteria that are requested.
     slot_usage:
@@ -138,7 +138,7 @@ enums:
   IdentityCheckPolicyType:
     permissible_values:
       none:
-      published: 
+      published:
       money_laundering_regulations:
       physical_or_biometric_official:
 
@@ -147,30 +147,34 @@ slots:
     description: A unique transaction identifier for this check, or part of a check, if any.
     range: string
   strengthScore:
-    description: The strength score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#strength) 
+    description: The strength score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#strength)
     range: integer
     minimum_value: 1
     maximum_value: 4
   validityScore:
-    description: The validity score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#validity) 
+    description: The validity score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#validity)
     range: integer
     minimum_value: 0
     maximum_value: 4
   verificationScore:
-    description: The verification score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#verification) 
+    description: The verification score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#verification)
     range: integer
     minimum_value: 0
     maximum_value: 4
   activityHistoryScore:
-    description: The activity history score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#activity-history) 
+    description: The activity history score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#activity-history)
     range: integer
     minimum_value: 0
     maximum_value: 4
   identityFraudScore:
-    description: The identity fraud score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#identity-fraud) 
+    description: The identity fraud score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#identity-fraud)
     range: integer
     minimum_value: 0
     maximum_value: 3
+  ciReasons:
+    range: string
+    multivalued: true
+    inlined_as_list: true
   checkDetails:
     range: CheckDetailsClass
     multivalued: true
@@ -254,5 +258,5 @@ slots:
     description: The identifier of a verifiable credential.
     range: uri
   scoringPolicy:
-    description: The scoring policy that is applicable for the evidence requested scores.  The current supported scoring policy is `gpg45`.   
+    description: The scoring policy that is applicable for the evidence requested scores.  The current supported scoring policy is `gpg45`.
     range: string

--- a/v1/linkml-schemas/identityCheckCredential.yaml
+++ b/v1/linkml-schemas/identityCheckCredential.yaml
@@ -20,6 +20,7 @@ classes:
   IdentityCheckSubjectClass:
     is_a: PersonWithDocumentsClass
     slots:
+      - deviceId
       - address
   IdentityCheckCredentialClass:
     is_a: VerifiableCredentialClass
@@ -47,3 +48,6 @@ slots:
     multivalued: true
     inlined_as_list: true
     required: true
+  deviceId:
+    range: string
+    description: Identifier of the device


### PR DESCRIPTION
## What

### PostalAddressClass
* Added `poBoxNumber` which is in use by DCMAW and the Fraud CRIs. The `schema:postOfficeBoxNumber` was chosen as the closed mapping for `close_mappings`.
* Added `id` field which is in use by the DCMAW and the Fraud CRIs. This was added as an `attribute` rather than as a `slot` due to conflicts within LinkML, but outputs the field as `type: "string"`.

### IdentityCheckPolicyType
* Added the `ciReasons` which is an array of `string` in use by the Passport CRI.

### IdentityCheckSubjectClass
* Added `deviceId` which is in use by the App CRI.

### Other
* Minor whitespace clean up changes applied automatically upon save.

## Why
In order for us to enable the full schema checking within SPOT we need to update the data-vocab to reflect the current data being sent to SPOT from CRIs. If we enable full schema checking within SPOT with the current schema a large majority of requests would fail against the current schema.