### PR TITLE
RFC-0064 Adds RiskAssessment credential

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ This vocabulary covers a number of use cases in the GOV.UK One Login domain, inc
 * OAuth 2.0 [authorization requests](v1/classes/IssuerAuthorizationRequestClass) to credential issuing and credential collecting services
 * VCs for [identity proofing and verification](v1/classes/IdentityCheckCredentialClass)
 * VCs for [other security checks](v1/classes/SecurityCheckCredentialClass)
+* VCs for [risk assessments](v1/classes/RiskAssessmentCredentialClass)
 
 In future it may be extended to cover security events.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
           - IdentityCheckCredentialJWTClass: v1/classes/IdentityCheckCredentialJWTClass.md
           - IdentityCheckSubjectClass: v1/classes/IdentityCheckSubjectClass.md
           - InheritedIdentityJWTClass: v1/classes/InheritedIdentityJWTClass.md
+          - InterventionClass: v1/classes/InterventionClass.md
           - ISODateClass: v1/classes/ISODateClass.md
           - IssuerAuthorizationRequestClass: v1/classes/IssuerAuthorizationRequestClass.md
           - JWTClass: v1/classes/JWTClass.md
@@ -57,6 +58,9 @@ nav:
           - PersonWithIdentityClass: v1/classes/PersonWithIdentityClass.md
           - PostalAddressClass: v1/classes/PostalAddressClass.md
           - ResidencePermitDetailsClass: v1/classes/ResidencePermitDetailsClass.md
+          - RiskAssessmentClass: v1/classes/RiskAssessmentClass.md
+          - RiskAssessmentCredentialClass: v1/classes/RiskAssessmentCredentialClass.md
+          - RiskAssessmentCredentialJWTClass: v1/classes/RiskAssessmentCredentialJWTClass.md
           - SecurityCheckClass: v1/classes/SecurityCheckClass.md
           - SecurityCheckCredentialClass: v1/classes/SecurityCheckCredentialClass.md
           - SecurityCheckCredentialJWTClass: v1/classes/SecurityCheckCredentialJWTClass.md
@@ -152,6 +156,9 @@ nav:
           - identityFraudScore: v1/slots/identityFraudScore.md
           - incompleteMitigation: v1/slots/incompleteMitigation.md
           - inheritedIdentityJWTClass__vc: v1/slots/inheritedIdentityJWTClass__vc.md
+          - intervention: v1/slots/intervention.md
+          - interventionCode: v1/slots/interventionCode.md
+          - interventionReason: v1/slots/interventionReason.md
           - iSODateClass__value: v1/slots/iSODateClass__value.md
           - iss: v1/slots/iss.md
           - issuanceDate: v1/slots/issuanceDate.md
@@ -181,6 +188,10 @@ nav:
           - residencePermit: v1/slots/residencePermit.md
           - ResidencePermitDetailsClass_expiryDate: v1/slots/ResidencePermitDetailsClass_expiryDate.md
           - response_type: v1/slots/response_type.md
+          - riskAssessmentClass__type: v1/slots/riskAssessmentClass__type.md
+          - riskAssessmentCredentialClass__evidence: v1/slots/riskAssessmentCredentialClass__evidence.md
+          - riskAssessmentCredentialClass__type: v1/slots/riskAssessmentCredentialClass__type.md
+          - riskAssessmentCredentialJWTClass__vc: v1/slots/riskAssessmentCredentialJWTClass__vc.md
           - scope: v1/slots/scope.md
           - scoringPolicy: v1/slots/scoringPolicy.md
           - securityCheckClass__type: v1/slots/securityCheckClass__type.md

--- a/scripts/generate_json_schemas.sh
+++ b/scripts/generate_json_schemas.sh
@@ -26,6 +26,7 @@ LINKML_ITEMS=(
   "document.yaml,PassportDetailsClass,PassportDetails.json"
   "address.yaml,PostalAddressClass,PostalAddress.json"
   "document.yaml,ResidencePermitDetailsClass,ResidencePermit.json"
+  "riskAssessmentCredential.yaml,RiskAssessmentCredentialClass,RiskAssessmentCredential.json"
   "securityCheckCredential.yaml,SecurityCheckCredentialClass,SecurityCheckCredential.json"
   "document.yaml,SocialSecurityRecordDetailsClass,SocialSecurityRecord.json"
   "document.yaml,BankAccountDetailsClass,BankAccount.json"

--- a/v1/linkml-schemas/credentials.yaml
+++ b/v1/linkml-schemas/credentials.yaml
@@ -17,6 +17,7 @@ imports:
   - ./verifiableIdentityCredential
   - ./identityCheckCredential
   - ./securityCheckCredential
+  - ./riskAssessmentCredential
 default_curi_maps:
   - semweb_context
 default_prefix: di_vocab
@@ -125,6 +126,14 @@ classes:
         required: true
       jti:
         pattern: "(?!\\s*$).+"
+
+  RiskAssessmentCredentialJWTClass:
+    is_a: JWTClass
+    attributes:
+      vc:
+        range: RiskAssessmentCredentialClass
+        required: true
+
   SecurityCheckCredentialJWTClass:
     is_a: JWTClass
     attributes:
@@ -236,4 +245,5 @@ enums:
       VerifiableIdentityCredential:
       IdentityAssertionCredential:
       AddressCredential:
+      RiskAssessmentCredential:
       SecurityCheckCredential:

--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -40,6 +40,18 @@ classes:
       - activityFrom
       - identityCheckLevel
       - identityCheckPolicy
+  RiskAssessmentClass:
+    attributes:
+      type:
+        equals_string: RiskAssessment
+    slots:
+      - txn
+      - ci
+      - intervention
+  InterventionClass:
+    slots:
+      - interventionCode
+      - interventionReason
   SecurityCheckClass:
     attributes:
       type:
@@ -186,6 +198,13 @@ slots:
   checkMethod:
     range: CheckMethodType
     description: An identifier from the OpenID Check Methods list
+  intervention:
+    range: InterventionClass
+    description: Intervention required by the risk assessment
+  interventionCode:
+    range: string
+  interventionReason:
+    range: string
   kbvQuality:
     range: integer
     minimum_value: 0

--- a/v1/linkml-schemas/riskAssessmentCredential.yaml
+++ b/v1/linkml-schemas/riskAssessmentCredential.yaml
@@ -1,0 +1,37 @@
+id: https://vocab.account.gov.uk/linkml/riskAssessmentCredential-schema
+name: RiskAssessment
+description: >-
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  vc: https://www.w3.org/2018/credentials/v1/
+  di_vocab: https://vocab.account.gov.uk/v1/
+imports:
+  - ./evidence
+  - ./credentials
+default_curi_maps:
+  - semweb_context
+default_prefix: di_vocab
+default_range: string
+
+classes:
+  RiskAssessmentCredentialClass:
+    is_a: VerifiableCredentialClass
+    description: |
+      A [VC](https://www.w3.org/TR/vc-data-model/) containing evidence pertaining to a risk assessment performed about a GOV.UK One Login account.
+
+      In GOV.UK One Login this VC is always [issued in JWT format](../RiskAssessmentCredentialJWTClass).
+
+      JSON schema: [RiskAssessmentCredential.json](../json-schemas/RiskAssessmentCredential.json)
+    attributes:
+      evidence:
+        range: RiskAssessmentClass
+        multivalued: true
+        inlined_as_list: true
+        required: true
+      type:
+        range: VerifiableCredentialType
+        multivalued: true
+    see_also:
+      - ../json-schemas/RiskAssessmentCredential.json
+


### PR DESCRIPTION
RFC 0064 introduces a new `RiskAssessmentCredential`, used by the TICF CRI. This adds the corresponding schema for it.

I've not pushed to this repo before, but I did build and check the site locally, and it appears ok.

Also not sure what the versioning/release policy is for new versions. Let me know if you'd like me to bump the version etc.