### PR TITLE
ATO-424: Add inheritedIdentityJWT

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
           - IdentityCheckCredentialClass: v1/classes/IdentityCheckCredentialClass.md
           - IdentityCheckCredentialJWTClass: v1/classes/IdentityCheckCredentialJWTClass.md
           - IdentityCheckSubjectClass: v1/classes/IdentityCheckSubjectClass.md
+          - InheritedIdentityJWTClass: v1/classes/InheritedIdentityJWTClass.md
           - ISODateClass: v1/classes/ISODateClass.md
           - IssuerAuthorizationRequestClass: v1/classes/IssuerAuthorizationRequestClass.md
           - JWTClass: v1/classes/JWTClass.md
@@ -150,6 +151,7 @@ nav:
           - identityCheckPolicy: v1/slots/identityCheckPolicy.md
           - identityFraudScore: v1/slots/identityFraudScore.md
           - incompleteMitigation: v1/slots/incompleteMitigation.md
+          - inheritedIdentityJWTClass__vc: v1/slots/inheritedIdentityJWTClass__vc.md
           - iSODateClass__value: v1/slots/iSODateClass__value.md
           - iss: v1/slots/iss.md
           - issuanceDate: v1/slots/issuanceDate.md

--- a/scripts/generate_json_schemas.sh
+++ b/scripts/generate_json_schemas.sh
@@ -19,6 +19,7 @@ LINKML_ITEMS=(
   "document.yaml,IdCardDetailsClass,IdCard.json"
   "identityCheckCredential.yaml,IdentityCheckCredentialClass,IdentityCheckCredential.json"
   "credentials.yaml,IdentityCheckCredentialJWTClass,IdentityCheckCredentialJWT.json"
+  "credentials.yaml,InheritedIdentityJWTClass,InheritedIdentityJWT.json"
   "credentials.yaml,IssuerAuthorizationRequestClass,IssuerAuthorizationRequest.json"
   "name.yaml,NameClass,Name.json"
   "credentials.yaml,OpenIDConnectAuthenticationRequestClass,OpenIDConnectAuthenticationRequest.json"

--- a/v1/linkml-schemas/credentials.yaml
+++ b/v1/linkml-schemas/credentials.yaml
@@ -85,6 +85,24 @@ classes:
         range: VerifiableIdentityCredentialClass
         required: true
 
+  InheritedIdentityJWTClass:
+    is_a: JWTClass
+    description: |
+      A [JWT-encoded VC](https://www.w3.org/TR/vc-data-model/#json-web-token) that wraps a
+      [verifiable identity credential](../VerifiableIdentityCredentialClass)
+      for migrating an identity from HMRC to GOV.UK One Login.
+
+      JSON schema: [InheritedIdentityJWT.json](../json-schemas/InheritedIdentityJWT.json)
+    see_also:
+      - ../json-schemas/InheritedIdentityJWT.json
+    slots:
+      - vot
+      - vtm
+    attributes:
+      vc:
+        range: VerifiableIdentityCredentialClass
+        required: true
+
   IdentityCheckCredentialJWTClass:
     description: |
       A [JWT-encoded VC](https://www.w3.org/TR/vc-data-model/#json-web-token) that wraps an


### PR DESCRIPTION
Add schema for `inheritedIdentityJWT` as a verifiable identity credential as described by https://github.com/govuk-one-login/architecture/pull/554