### PR TITLE
SPT-633 : Update Security Credential Json format

### DIFF
--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -228,7 +228,7 @@ slots:
     description: A system level code to indentify a contra-indicator.
   issuanceDate:
     description: The date a contra-indicator was generated.
-    range: date
+    range: datetime
   issuers:
     description: An array of cri issuers.
     range: uri
@@ -247,6 +247,7 @@ slots:
   mitigatingCredential:
     description: Details of the credential that was generated as part of the mitigation journey for a particular contra-indicator.
     range: MitigatingCredentialClass
+    multivalued: true
   issuer:
     description: The issuer of a verifiable credential.
     range: uri


### PR DESCRIPTION
### **What**

The date format in  Issuance date has been updated as per RFC-41 , the value for mitigationCredential  in Evidence is now  array instead of an Object.

### **Why**

The date format needs to be updated to date time to avoid validation failures , Contraindicator  subfields need to align with latest changes to mitigation Credential