### PR TITLE
Fix: Add max value to UPRN to ensure it is generated as a Java Long

### DIFF
--- a/v1/linkml-schemas/address.yaml
+++ b/v1/linkml-schemas/address.yaml
@@ -70,6 +70,7 @@ classes:
 slots:
   uprn:
     range: integer
+    minimum_value: 1
     maximum_value: 999999999999 # UPRNs can be up to 12 digits in length
     exact_mappings: adb:uprn
     description: The Unique Property Reference Number (UK and Northern Ireland Addresses Only)

--- a/v1/linkml-schemas/address.yaml
+++ b/v1/linkml-schemas/address.yaml
@@ -70,6 +70,7 @@ classes:
 slots:
   uprn:
     range: integer
+    maximum_value: 999999999999 # UPRNs can be up to 12 digits in length
     exact_mappings: adb:uprn
     description: The Unique Property Reference Number (UK and Northern Ireland Addresses Only)
                  <p>Exact mapping&#58; [adb:uprn](http://www.geoplace.co.uk/addressbase/schema/2.1/addressbase.xsd)</p>


### PR DESCRIPTION
By default, the Java type generation maps the `integer` type to a Java `Integer`, however this is only a 32-bit integer which is not long enough for a UPRN.

Adding a maximum value above the max Java int persuades it to map to a `Long` instead.