### PR TITLE
SPT-746:update Vocab schema to update Identity check type

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - DataCheckType: v1/enums/DataCheckType.md
           - FraudCheckType: v1/enums/FraudCheckType.md
           - IdentityCheckPolicyType: v1/enums/IdentityCheckPolicyType.md
+          - IdentityCheckType: v1/enums/IdentityCheckType.md
           - IdentityVectorOfTrust: v1/enums/IdentityVectorOfTrust.md
           - KBVResponseModeType: v1/enums/KBVResponseModeType.md
           - NamePartType: v1/enums/NamePartType.md

--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -155,10 +155,10 @@ enums:
       money_laundering_regulations:
       physical_or_biometric_official:
   IdentityCheckType:
+    description: IDENTITY_CHECK is no longer used, historic value for backward compatibility reasons only use IdentityCheck instead
     permissible_values:
       IDENTITY_CHECK:
       IdentityCheck:
-
 slots:
   txn:
     description: A unique transaction identifier for this check, or part of a check, if any.

--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -16,7 +16,8 @@ classes:
   IdentityCheckClass:
     attributes:
       type:
-        equals_string: IdentityCheck
+        range: IdentityCheckType
+        description: Identity check type values allowed
     slots:
       - txn
       - strengthScore
@@ -153,6 +154,10 @@ enums:
       published: 
       money_laundering_regulations:
       physical_or_biometric_official:
+  IdentityCheckType:
+    permissible_values:
+      IDENTITY_CHECK:
+      IdentityCheck:
 
 slots:
   txn:

--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -155,9 +155,10 @@ enums:
       money_laundering_regulations:
       physical_or_biometric_official:
   IdentityCheckType:
-    description: IDENTITY_CHECK is no longer used, historic value for backward compatibility reasons only use IdentityCheck instead
     permissible_values:
       IDENTITY_CHECK:
+        deprecated: Historic value for backward compatibility reasons only use IdentityCheck instead.
+        deprecated_element_has_exact_replacement: IdentityCheck
       IdentityCheck:
 slots:
   txn:


### PR DESCRIPTION
### What

When validating the credential in Spot we have failure for  Driving license Credential issuer (review-d), this is  because in the past driving license sent Identity check type  as IDENTIY_CHECK

### Why

Some old reused credentials still have IDENTITY_CHECK as Identity check type, we need to support both values IdentityCheck/IDENTTIY_CHECK values  for identity Check type.[SPT-746]


[SPT-746]: https://govukverify.atlassian.net/browse/SPT-746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ