### PR TITLE
SPT-767 Made Mitigating validFrom datetime

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
           - kbvQuality: v1/slots/kbvQuality.md
           - kbvResponseMode: v1/slots/kbvResponseMode.md
           - mitigatingCredential: v1/slots/mitigatingCredential.md
+          - mitigatingCredentialClass__validFrom: v1/slots/mitigatingCredentialClass__validFrom.md
           - mitigation: v1/slots/mitigation.md
           - name: v1/slots/name.md
           - nameParts: v1/slots/nameParts.md

--- a/scripts/test
+++ b/scripts/test
@@ -7,6 +7,7 @@ ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/IdentityCheckCredential.
 ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/IdentityCheckCredential.json -d $HERE/../v1/examples/driving-permit.json
 ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/IdentityCheckCredentialJWT.json -d $HERE/../v1/examples/app-gdc-liveness-likeness-jwt.json
 ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/IdentityCheckCredentialJWT.json -d $HERE/../v1/examples/identity-check-jwt.json
+ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/SecurityCheckCredentialJWT.json -d $HERE/../v1/examples/security-check-jwt.json
 ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/IssuerAuthorizationRequest.json -d $HERE/../v1/examples/core-cri-authz-request.json
 ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/OpenIDConnectAuthenticationRequest.json -d $HERE/../v1/examples/rp-authz-request.json
 ajv validate -c ajv-formats -s $HERE/../v1/json-schemas/DeathRegisteredJWT.json -d $HERE/../v1/examples/life-events/death-registered.json

--- a/v1/examples/security-check-jwt.json
+++ b/v1/examples/security-check-jwt.json
@@ -1,0 +1,43 @@
+{
+    "sub": "urn:uuid:01a0aaa6-5593-40d3-ac8e-eef1f0b8bf1a",
+    "iss": "did:web:identity.build.account.gov.uk:cimit",
+    "nbf": 1713792518,
+    "iat": 1713792518,
+    "exp": 1714656518,
+    "vc": {
+        "type": [
+            "VerifiableCredential",
+            "SecurityCheckCredential"
+        ],
+        "evidence": [
+            {
+                "type": "SecurityCheck",
+                "contraIndicator": [
+                    {
+                        "code": "A01",
+                        "issuers": [
+                            "https://build-di-ipv-cri-fraud-stub.london.cloudapps.digital"
+                        ],
+                        "issuanceDate": "2022-09-30T15:11:02.000Z",
+                        "txn": [
+                            "361704C6-F6CC-4D40-869A-ACDD64C03886"
+                        ],
+                        "mitigation": [
+                            {
+                                "code": "A01",
+                                "mitigatingCredential": [
+                                    {
+                                        "validFrom": "2022-09-30T15:11:10.000Z",
+                                        "txn": "361704C6-F6CC-4D40-869A-ACDD64C03886",
+                                        "id": "01FF95A9-89A9-4A0E-ACF8-4EFFF36AF990"
+                                    }
+                                ]
+                            }
+                        ],
+                        "incompleteMitigation": []
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -74,9 +74,11 @@ classes:
       - code
       - mitigatingCredential
   MitigatingCredentialClass:
+    attributes:
+      validFrom:
+        range: datetime
     slots:
       - issuer
-      - validFrom
       - txn
       - id 
   


### PR DESCRIPTION
## What

Updated MitigatingCredentialClass.validFrom field to `datetime`.

## Why

CIMIT is required to produce `validFrom` in ISO time and date format. So the `validFrom` field needs to be changed to datetime.