### PR TITLE
feat: Update InheritedIdentityJWT to contain an IdentityCheckCredential

### DIFF
--- a/v1/linkml-schemas/credentials.yaml
+++ b/v1/linkml-schemas/credentials.yaml
@@ -101,7 +101,7 @@ classes:
       - vtm
     attributes:
       vc:
-        range: VerifiableIdentityCredentialClass
+        range: IdentityCheckCredentialClass
         required: true
 
   IdentityCheckCredentialJWTClass:


### PR DESCRIPTION
The Inherited Identity JWT will always contain an `IdentityCheckCredential`.

The existing link to `VerifiableCredential` only includes the base VC fields, rather than a concrete implementation.