### PR TITLE
fix: Make person a valid credential subject

### DIFF
--- a/v1/linkml-schemas/common.yaml
+++ b/v1/linkml-schemas/common.yaml
@@ -42,6 +42,14 @@ classes:
         range: string
         description: The date in the form CCYY[-MM[-DD]]
 
+  CredentialSubjectClass:
+    description: Verifiable credential subjects use multiple inheritance; this base class is intentionally blank.
+    see_also:
+      - /v1/IdentityCheckCredentialClass_credentialSubject
+      - /v1/AddressCredentialClass_credentialSubject
+      - /v1/IdentityAssertionCredentialClass_credentialSubject
+      - /v1/VerifiableIdentityCredentialClass_credentialSubject
+
 types:
   JWS:
     uri: "https://www.iana.org/assignments/media-types/application/jose"

--- a/v1/linkml-schemas/credentials.yaml
+++ b/v1/linkml-schemas/credentials.yaml
@@ -213,14 +213,6 @@ classes:
       credentialSubject:
         range: AddressAssertionClass
 
-  CredentialSubjectClass:
-    description: Verifiable credential subjects use multiple inheritance; this base class is intentionally blank.
-    see_also:
-      - /v1/IdentityCheckCredentialClass_credentialSubject
-      - /v1/AddressCredentialClass_credentialSubject
-      - /v1/IdentityAssertionCredentialClass_credentialSubject
-      - /v1/VerifiableIdentityCredentialClass_credentialSubject
-
 slots:
   credentialJWT:
     range: JWS

--- a/v1/linkml-schemas/person.yaml
+++ b/v1/linkml-schemas/person.yaml
@@ -15,6 +15,7 @@ default_range: string
 
 classes:
   PersonClass:
+    is_a: CredentialSubjectClass
     class_uri: schema:Person
 
   PersonWithIdentityClass:


### PR DESCRIPTION
At the moment the inheritance hierarchy generated by the schema doesn't quite work for credential subjects.

For example:
- `IdentityCheckCredential` extends `VerifiableCredential`
- `IdentityCheckCredential.credentialSubject` is an `IdentityCheckSubject`
    - extends `PersonWithDocuments`
    - extends `PersonWithIdentity`
    - extends `Person`
- `VerifiableCredential.credentialSubject` is a `CredentialSubject`
- But `IdentityCheckSubject` is not a `CredentialSubject`, so the override for `credentialSubject` is not valid.

This can be fixed by making `Person` be a `CredentialSubject` (and this fixes it everywhere, as currently all `CredentialSubject`s are ultimately a `Person`). If we need other types of subject, we can do the same thing.