### PR TITLE
SPT-808: Add Java schema-artefacts package generation

### DIFF
--- a/code-generators/java-types/jackson-annotated/build.gradle
+++ b/code-generators/java-types/jackson-annotated/build.gradle
@@ -35,7 +35,7 @@ java {
 // see https://github.com/joelittlejohn/jsonschema2pojo/tree/master/jsonschema2pojo-gradle-plugin#usage
 jsonSchema2Pojo {
     // Location of the JSON Schema file(s). This may refer to a single file or a directory of files.
-    source = files(schemaInputDir)
+    source = files("${schemaInputDir}/combined")
 
     // Target directory for generated Java source files. The plugin will add this directory to the
     // java source set so the compiler will find and compile the newly generated source files.

--- a/code-generators/java-types/plain-pojo/build.gradle
+++ b/code-generators/java-types/plain-pojo/build.gradle
@@ -34,7 +34,7 @@ java {
 // see https://github.com/joelittlejohn/jsonschema2pojo/tree/master/jsonschema2pojo-gradle-plugin#usage
 jsonSchema2Pojo {
     // Location of the JSON Schema file(s). This may refer to a single file or a directory of files.
-    source = files(schemaInputDir)
+    source = files("${schemaInputDir}/combined")
 
     // Target directory for generated Java source files. The plugin will add this directory to the
     // java source set so the compiler will find and compile the newly generated source files.

--- a/code-generators/java-types/schema-artefacts/build.gradle
+++ b/code-generators/java-types/schema-artefacts/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id "java"
+    id "maven-publish"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = mavenGroupId
+            artifactId = 'di-data-model-schema'
+            version = project.version
+
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/govuk-one-login/data-vocab"
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
+
+task copySchemaFiles(type: Copy) {
+    from "${schemaInputDir}/separate/"
+    into layout.buildDirectory.dir("resources/main/uk/gov/di/model/schema")
+}
+
+processResources.dependsOn(copySchemaFiles)

--- a/code-generators/java-types/schema-artefacts/build.gradle
+++ b/code-generators/java-types/schema-artefacts/build.gradle
@@ -4,7 +4,11 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    repositories {
+        maven {
+            url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+        }
+    }
 }
 
 dependencies {

--- a/code-generators/java-types/schema-artefacts/src/main/java/uk/gov/di/model/schema/VocabSchemaLoader.java
+++ b/code-generators/java-types/schema-artefacts/src/main/java/uk/gov/di/model/schema/VocabSchemaLoader.java
@@ -1,0 +1,14 @@
+package uk.gov.di.model.schema;
+
+import java.io.InputStream;
+
+public class VocabSchemaLoader {
+
+    private VocabSchemaLoader() {
+    }
+
+    public static InputStream getSchema(String name) {
+        return VocabSchemaLoader.class
+                .getResourceAsStream(name);
+    }
+}

--- a/code-generators/java-types/schema-artefacts/src/main/java/uk/gov/di/model/schema/VocabSchemaLoader.java
+++ b/code-generators/java-types/schema-artefacts/src/main/java/uk/gov/di/model/schema/VocabSchemaLoader.java
@@ -1,8 +1,18 @@
 package uk.gov.di.model.schema;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static java.util.Objects.nonNull;
 
 public class VocabSchemaLoader {
+
+    public static final String IDENTITY_CHECK_CREDENTIAL_JWT_NAME = "IdentityCheckCredentialJWT.json";
+    public static final String INHERITED_IDENTITY_JWT_NAME = "InheritedIdentityJWT.json";
+    public static final String RISK_ASSESSMENT_CREDENTIAL_JWT_NAME = "RiskAssessmentCredentialJWT.json";
+    public static final String SECURITY_CHECK_CREDENTIAL_JWT_NAME = "SecurityCheckCredentialJWT.json";
 
     private VocabSchemaLoader() {
     }
@@ -10,5 +20,15 @@ public class VocabSchemaLoader {
     public static InputStream getSchema(String name) {
         return VocabSchemaLoader.class
                 .getResourceAsStream(name);
+    }
+
+    public static String getSchemaAsString(String name) {
+        try (var stream = VocabSchemaLoader.class.getResourceAsStream(name)){
+            if (nonNull(stream)) {
+                return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
     }
 }

--- a/code-generators/java-types/schema-artefacts/src/test/java/uk/gov/di/model/schema/VocabSchemaLoaderTest.java
+++ b/code-generators/java-types/schema-artefacts/src/test/java/uk/gov/di/model/schema/VocabSchemaLoaderTest.java
@@ -1,24 +1,59 @@
 package uk.gov.di.model.schema;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.model.schema.VocabSchemaLoader.IDENTITY_CHECK_CREDENTIAL_JWT_NAME;
+import static uk.gov.di.model.schema.VocabSchemaLoader.INHERITED_IDENTITY_JWT_NAME;
+import static uk.gov.di.model.schema.VocabSchemaLoader.RISK_ASSESSMENT_CREDENTIAL_JWT_NAME;
+import static uk.gov.di.model.schema.VocabSchemaLoader.SECURITY_CHECK_CREDENTIAL_JWT_NAME;
 
 class VocabSchemaLoaderTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-            "IdentityCheckCredentialJWT.json",
-            "InheritedIdentityJWT.json",
-            "RiskAssessmentCredentialJWT.json",
-            "SecurityCheckCredentialJWT.json",
+            IDENTITY_CHECK_CREDENTIAL_JWT_NAME,
+            INHERITED_IDENTITY_JWT_NAME,
+            RISK_ASSESSMENT_CREDENTIAL_JWT_NAME,
+            SECURITY_CHECK_CREDENTIAL_JWT_NAME,
     })
-    void getSchema(String schemaName) throws IOException {
+    void shouldReturnInputStreamWhenPassedValidSchemaNames(String schemaName) throws IOException {
         try (var schema = VocabSchemaLoader.getSchema(schemaName)) {
             assertNotNull(schema);
         }
+    }
+
+    @Test
+    void shouldReturnNullStreamWhenPassedInvalidSchemaName() {
+        assertNull(VocabSchemaLoader.getSchema("does-not-exist.json"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            IDENTITY_CHECK_CREDENTIAL_JWT_NAME,
+            INHERITED_IDENTITY_JWT_NAME,
+            RISK_ASSESSMENT_CREDENTIAL_JWT_NAME,
+            SECURITY_CHECK_CREDENTIAL_JWT_NAME,
+    })
+    void shouldReturnSchemaAsStringWhenPassedValidSchemaNames(String schemaName) {
+        var schema = VocabSchemaLoader.getSchemaAsString(schemaName);
+
+        assertNotNull(schema);
+        assertTrue(schema.trim().startsWith("{"));
+        assertTrue(schema.trim().endsWith("}"));
+    }
+
+    @Test
+    void shouldReturnNullStringWhenPassedInvalidSchemaName() {
+        assertNull(VocabSchemaLoader.getSchemaAsString("does-not-exist.json"));
     }
 }

--- a/code-generators/java-types/schema-artefacts/src/test/java/uk/gov/di/model/schema/VocabSchemaLoaderTest.java
+++ b/code-generators/java-types/schema-artefacts/src/test/java/uk/gov/di/model/schema/VocabSchemaLoaderTest.java
@@ -1,0 +1,24 @@
+package uk.gov.di.model.schema;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class VocabSchemaLoaderTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "IdentityCheckCredentialJWT.json",
+            "InheritedIdentityJWT.json",
+            "RiskAssessmentCredentialJWT.json",
+            "SecurityCheckCredentialJWT.json",
+    })
+    void getSchema(String schemaName) throws IOException {
+        try (var schema = VocabSchemaLoader.getSchema(schemaName)) {
+            assertNotNull(schema);
+        }
+    }
+}

--- a/code-generators/java-types/settings.gradle
+++ b/code-generators/java-types/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'di-data-model'
 
 include ':jackson-annotated'
 include ':plain-pojo'
+include 'schema-artefacts'
 
 dependencyResolutionManagement {
     versionCatalogs {
@@ -16,5 +17,3 @@ dependencyResolutionManagement {
         }
     }
 }
-include 'schema-artefacts'
-

--- a/code-generators/java-types/settings.gradle
+++ b/code-generators/java-types/settings.gradle
@@ -16,3 +16,5 @@ dependencyResolutionManagement {
         }
     }
 }
+include 'schema-artefacts'
+

--- a/scripts/generate_java_types.sh
+++ b/scripts/generate_java_types.sh
@@ -8,7 +8,10 @@ JSON_SCHEMA_DIR="${ROOT_DIR}/code-generators/java-types/schemas"
 
 # Generate intermediate json-schema used for the Java type generation
 cd "${ROOT_DIR}/scripts"
-./generate_json_schemas.sh -j "$JSON_SCHEMA_DIR" -o combined
+./generate_json_schemas.sh -j "${JSON_SCHEMA_DIR}/combined" -o combined
+
+# Generate all json-schema used for the Java schema package generation
+./generate_json_schemas.sh -j "${JSON_SCHEMA_DIR}/separate"
 
 cd "${ROOT_DIR}/code-generators/java-types"
 ./gradlew clean build

--- a/scripts/generate_json_schemas.sh
+++ b/scripts/generate_json_schemas.sh
@@ -52,7 +52,6 @@ JSON_SCHEMA_DIR="${ROOT_DIR}/v1/json-schemas"
 # to control whether multiple or combined JSON Schema
 # files are produced.
 OUTPUT_MODE="separate"
-
 while getopts "j:o:l:" opt; do
   case ${opt} in
     j )
@@ -86,7 +85,7 @@ function prep_output_dir() {
 # Writes separate JSON Schema files.
 #
 function generate_separate_files() {
-  cp $JSON_SCHEMA_DIR/index.md.template $JSON_SCHEMA_DIR/index.md
+  [[ -f $JSON_SCHEMA_DIR/index.md.template ]] && cp $JSON_SCHEMA_DIR/index.md.template $JSON_SCHEMA_DIR/index.md
 
   for LINKML_ITEM in "${LINKML_ITEMS[@]}"; do
     ITEM_DETAILS=(${LINKML_ITEM//,/ })
@@ -97,8 +96,8 @@ function generate_separate_files() {
 
     poetry run gen-json-schema --closed --no-metadata -t "${LINKML_CLASS}" \
       "${LINKML_SCHEMA_DIR}/${LINKML_SCHEMA}" > "${JSON_SCHEMA_DIR}/${JSON_SCHEMA}"
-    echo "| [$JSON_SCHEMA]($JSON_SCHEMA) | [$LINKML_CLASS](../classes/$LINKML_CLASS) |" >> $JSON_SCHEMA_DIR/index.md
-    poetry run python ./scripts/check_schema_see_also.py  "${LINKML_SCHEMA_DIR}/${LINKML_SCHEMA}" $LINKML_CLASS ../json-schemas/$JSON_SCHEMA
+    [[ -f $JSON_SCHEMA_DIR/index.md ]] && echo "| [$JSON_SCHEMA]($JSON_SCHEMA) | [$LINKML_CLASS](../classes/$LINKML_CLASS) |" >> $JSON_SCHEMA_DIR/index.md
+    poetry run python ${ROOT_DIR}/scripts/check_schema_see_also.py  "${LINKML_SCHEMA_DIR}/${LINKML_SCHEMA}" $LINKML_CLASS ../json-schemas/$JSON_SCHEMA
   done
 }
 


### PR DESCRIPTION
## What

- Add new Gradle `schema-artefacts` module
- Alter `generate_java_types.sh` to also generate separate schema
  generation in to a different directoy
- Amend `generate_json_schemas.sh` so as not generate `index.md` if
  template not present in target directory
- Add `VocabSchemaLoader` class to retreive schema from resources and
  return as `InputStream`

## Why

Allow generation and publishing of a package to Maven repo such that schemas can be imported into projects and managed through Dependabot.
