### PR TITLE
Added decisionScore to IdentityCheck

### DIFF
--- a/v1/linkml-schemas/evidence.yaml
+++ b/v1/linkml-schemas/evidence.yaml
@@ -24,6 +24,7 @@ classes:
       - validityScore
       - verificationScore
       - activityHistoryScore
+      - decisionScore
       - identityFraudScore
       - checkDetails
       - failedCheckDetails
@@ -186,6 +187,9 @@ slots:
     range: integer
     minimum_value: 0
     maximum_value: 4
+  decisionScore:
+    description: The decision score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#strength)
+    range: integer
   identityFraudScore:
     description: The identity fraud score based on the check that has taken place as defined in the [Good Practice Guide 45 documentation](https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/how-to-prove-and-verify-someones-identity#identity-fraud) 
     range: integer


### PR DESCRIPTION
I have noticed the Fraud CRI VC Issued event contains this `decisionScore` attribute which isn't present here. I'm not familiar with this enough to know if this should be added here but raising a PR to bring attention to it.

It would also be good if someone can add in a minimum and maximum value and review the description.