### PR TITLE
SPT-896: Added compilation of typescript-schemas

### DIFF
--- a/code-generators/typescript-schemas/package.json
+++ b/code-generators/typescript-schemas/package.json
@@ -22,7 +22,9 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "copy-pkg-misc": "cp ./src/package-template.json ./dist/package.json && cp ../../README.md ./src/tsconfig.json ./dist",
-    "generate": "npm run generate-schemas && npm run copy-pkg-misc",
-    "generate-schemas": "node ./src/index.mjs $PWD/schemas $PWD/dist"
+    "generate": "npm run generate-schemas && npm run generate-tsconfig && npm run generate-source && npm run copy-pkg-misc",
+    "generate-schemas": "node ./src/index.mjs $PWD/schemas $PWD/dist",
+    "generate-tsconfig": "cp ./src/tsconfig.json $PWD/dist/",
+    "generate-source": "tsc -p ./dist/tsconfig.json"
   }
 }

--- a/code-generators/typescript-schemas/src/package-template.json
+++ b/code-generators/typescript-schemas/src/package-template.json
@@ -14,5 +14,6 @@
   },
   "scripts": {
     "build": "tsc"
-  }
+  },
+  "main": "dist/index.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "eslint-config-airbnb-base": "^14.2.1",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jest": "^24.7.0",
+        "typescript": "^5.5.3",
         "webpack": "^5.76.0",
         "webpack-cli": "^5.0.1"
       }
@@ -3704,17 +3705,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6756,11 +6756,10 @@
       "peer": true
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true,
-      "peer": true
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^24.7.0",
+    "typescript": "^5.5.3",
     "webpack": "^5.76.0",
     "webpack-cli": "^5.0.1"
   },
@@ -24,6 +25,5 @@
   "browser": {
     "assert": false
   },
-  "dependencies": {},
   "scripts": {}
 }


### PR DESCRIPTION
It was not possible to use the compiled @govuk-one-login/ typescript-schemas package without a lot of changes to client code bases as the Typescript code had not been compiled.

This change adds:
* The steps required to compile the Typescript code to .js without the need to add additional flags to transpile it
* Add a `main` to the package.json which allows clients to use the library
* Cleans up the index.mjs to make it easier to read.
* Adds Typescript as a dependency so that the compilation can take place