### PR TITLE
PYIC-7489 publish jsonschema for BirthDate

### DIFF
--- a/scripts/generate_json_schemas.sh
+++ b/scripts/generate_json_schemas.sh
@@ -11,6 +11,7 @@ set -e
 
 # format: <linkml schema file>,<linkml class>,<json schema file>
 LINKML_ITEMS=(
+  "person.yaml,BirthDateClass,BirthDate.json"
   "credentials.yaml,AddressCredentialJWTClass,AddressCredentialJWT.json"
   "credentials.yaml,AuthorizationRequestClass,AuthorizationRequest.json"
   "credentials.yaml,CoreIdentityJWTClass,CoreIdentityJWT.json"

--- a/v1/linkml-schemas/person.yaml
+++ b/v1/linkml-schemas/person.yaml
@@ -38,6 +38,9 @@ classes:
       - address
 
   BirthDateClass:
+    description: >-
+      BirthDate object that represents a user's claimed date of birth.
+      <p>JSON schema&#58; [di_vocab:BirthDate](../json-schemas/BirthDate.json)</p>
     mixins:
       - ValidityClass
     attributes:
@@ -46,6 +49,8 @@ classes:
         required: true
     slots:
       - description
+    see_also:
+      - ../json-schemas/BirthDate.json
 
   SexClass:
     slots:


### PR DESCRIPTION
We currently publish a separate schema for all the other core identity properties - Name/Passport/DrivingPermit/etc., which we can reference from our API schemas.

Alternatively we could publish a new schema for the core identity which contains all of them, but this seemed simpler.

(See also: https://github.com/govuk-one-login/ipv-core-back/pull/2529/files#diff-4f45a9aa5a096895d7a605dfb49deef21bacededbdd6b3480d69ae386c23c735)