### PR TITLE
BAU: Add a script to auto-generate release tag

### DIFF
--- a/.github/workflows/detect-and-tag-release.yml
+++ b/.github/workflows/detect-and-tag-release.yml
@@ -1,0 +1,65 @@
+name: Detect New Release and Tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  detect-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.13.x
+
+      - name: Detect Release Numbers
+        id: detect-releases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DETECTED="$(npm pkg get version | sed 's/"//g')"
+          CURRENT="$(gh release list -L 1 --json name --exclude-drafts --exclude-pre-releases -q '.[0].name')"
+
+          echo "detected-release=${DETECTED}"
+          echo "current-release=${CURRENT}"
+          
+          echo "detected-release=${DETECTED}" >> "${GITHUB_OUTPUT}"
+          echo "current-release=${CURRENT}" >> "${GITHUB_OUTPUT}"
+
+      - name: Sense Check Release
+        shell: bash
+        env:
+          NPM_RELEASE: ${{ steps.detect-releases.outputs.detected-release }}
+        run: |
+          GRADLE_RELEASE="$(cat code-generators/java-types/gradle.properties | grep '^version=' | sed 's/version=//g')"
+          
+          echo "Gradle Release is ${GRADLE_RELEASE}"
+          echo "NPM Release is ${NPM_RELEASE}"
+          
+          if [[ "${GRADLE_RELEASE}" != "${NPM_RELEASE}" ]]
+          then
+            echo "Releases are not in sync"
+            exit 1
+          fi
+
+      - name: Create tag
+        uses: actions/github-script@v5
+        if: "format('v{0}', steps.detect-releases.outputs.detected-release) != steps.detect-releases.outputs.current-release"
+        env:
+          RELEASE: ${{ steps.detect-releases.outputs.detected-release }}
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/v${process.env.RELEASE}`,
+              sha: context.sha
+            })

--- a/README.md
+++ b/README.md
@@ -249,13 +249,10 @@ New version: 1.7.2
 Commit changes and create tag (y/N)?
 ```
 
-Once you have confirmed the version, the script will commit the changes and create a tag for the release.
+Once you have confirmed the version, the script will commit the changes.
 
-> **Note**
-> You must push the tag and update the `main` branch to trigger the release process.
-> 
-> ```shell
-> git push origin main --tags
-> ```
+Now raise a PR and seek a review. Once approved, merge the PR.
 
-On push, the GitHub Actions workflow will build and publish the artifacts to GitHub Packages and the vocab static site.
+On merge, the `detect-and-tag-release` workflow will detect the release number change and automatically tag the
+commit with the release number. This, in turn, will trigger the `publish` workflow to publish the artefacts to GitHub 
+Packages.

--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -44,9 +44,9 @@ function update_java_generator() {
 }
 
 #
-# Commits the changes to git and tags it.
+# Commits the changes to git
 #
-function commit_and_tag() {
+function commit() {
   local NEW_VERSION="$1"
   cd "${ROOT_DIR}"
 
@@ -57,8 +57,7 @@ function commit_and_tag() {
     code-generators/typescript-types/package.json \
     code-generators/typescript-types/package-lock.json
 
-  git commit -m"build: release ${NEW_VERSION}."
-  git tag "v$NEW_VERSION"
+  git commit -m "build: release ${NEW_VERSION}."
 }
 
 update_root_project
@@ -76,4 +75,4 @@ if [[ -z "$CONFIRM_COMMIT" || "y" != "$CONFIRM_COMMIT" ]]; then
   exit 1
 fi
 
-commit_and_tag "${NEW_VERSION}"
+commit "${NEW_VERSION}"


### PR DESCRIPTION
## What

Add new workflow that detects changes to the artefact version numbers stored in `package.json` and `gradle.properties` for the code generators.

If the versions number differ from the current release, automatically generate a tag which, in turn will trigger the publish process.

## Why

Automation of the artefact release process.

