### PR TITLE
BAU: Remove `v` prefix when publishing packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Calculate release name
         id: release-name
         run: |
-          echo "release_version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          echo "release_version=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Download combined schema
         uses: actions/download-artifact@v4
@@ -128,7 +129,8 @@ jobs:
       - name: Calculate release name
         id: release-name
         run: |
-          echo "release_version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          echo "release_version=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Publish npm package
         working-directory: code-generators/typescript-schemas/dist


### PR DESCRIPTION
When publishing packages, ensure the `v` prefix is removed from the version name (the `v` should be retained while creating the GitHub release).

The inclusion of the `v` is proving troublesome with the Maven repository, NPM is clever enough to remove `v` but the Gradle publish action just uses the version verbatim and downstream this causes Dependabot to do strange things.