### PR TITLE
Pinned NPM dependencies to specific version

### DIFF
--- a/code-generators/typescript-schemas/src/package-template.json
+++ b/code-generators/typescript-schemas/src/package-template.json
@@ -10,7 +10,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "5.4.5"
   },
   "scripts": {
     "build": "tsc"

--- a/code-generators/typescript-types/package-lock.json
+++ b/code-generators/typescript-types/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.9.3",
       "license": "ISC",
       "dependencies": {
-        "json-schema-to-typescript": "^13.1.1"
+        "json-schema-to-typescript": "13.1.1"
       },
       "devDependencies": {
-        "rimraf": "^5.0.5"
+        "rimraf": "5.0.5"
       }
     },
     "node_modules/@bcherny/json-schema-ref-parser": {
@@ -461,9 +461,10 @@
       }
     },
     "node_modules/json-schema-to-typescript": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-13.1.2.tgz",
-      "integrity": "sha512-17G+mjx4nunvOpkPvcz7fdwUwYCEwyH8vR3Ym3rFiQ8uzAL3go+c1306Kk7iGRk8HuXBXqy+JJJmpYl0cvOllw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-13.1.1.tgz",
+      "integrity": "sha512-F3CYhtA7F3yPbb8vF7sFchk/2dnr1/yTKf8RcvoNpjnh67ZS/ZMH1ElLt5KHAtf2/bymiejLQQszszPWEeTdSw==",
+      "license": "MIT",
       "dependencies": {
         "@bcherny/json-schema-ref-parser": "10.0.5-fork",
         "@types/json-schema": "^7.0.11",
@@ -646,6 +647,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
       "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
       },
@@ -1337,9 +1339,9 @@
       }
     },
     "json-schema-to-typescript": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-13.1.2.tgz",
-      "integrity": "sha512-17G+mjx4nunvOpkPvcz7fdwUwYCEwyH8vR3Ym3rFiQ8uzAL3go+c1306Kk7iGRk8HuXBXqy+JJJmpYl0cvOllw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-13.1.1.tgz",
+      "integrity": "sha512-F3CYhtA7F3yPbb8vF7sFchk/2dnr1/yTKf8RcvoNpjnh67ZS/ZMH1ElLt5KHAtf2/bymiejLQQszszPWEeTdSw==",
       "requires": {
         "@bcherny/json-schema-ref-parser": "10.0.5-fork",
         "@types/json-schema": "^7.0.11",

--- a/code-generators/typescript-types/package.json
+++ b/code-generators/typescript-types/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "version": "1.9.3",
   "devDependencies": {
-    "rimraf": "^5.0.5"
+    "rimraf": "5.0.5"
   },
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
     "assert": false
   },
   "dependencies": {
-    "json-schema-to-typescript": "^13.1.1"
+    "json-schema-to-typescript": "13.1.1"
   },
   "scripts": {
     "clean": "rimraf ./dist",

--- a/examples/schemas-typescript/package-lock.json
+++ b/examples/schemas-typescript/package-lock.json
@@ -10,11 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@govuk-one-login/data-vocab-schemas": "1.7.2",
-        "ajv": "^8.16.0",
-        "ajv-formats": "^3.0.1"
+        "ajv": "8.16.0",
+        "ajv-formats": "3.0.1"
       },
       "devDependencies": {
-        "typescript": "^5.2.2"
+        "typescript": "5.2.2"
       }
     },
     "node_modules/@govuk-one-login/data-vocab-schemas": {
@@ -26,6 +26,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
       "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -41,6 +42,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -80,10 +82,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/schemas-typescript/package.json
+++ b/examples/schemas-typescript/package.json
@@ -12,10 +12,10 @@
   "license": "ISC",
   "dependencies": {
     "@govuk-one-login/data-vocab-schemas": "1.7.2",
-    "ajv": "^8.16.0",
-    "ajv-formats": "^3.0.1"
+    "ajv": "8.16.0",
+    "ajv-formats": "3.0.1"
   },
   "devDependencies": {
-    "typescript": "^5.2.2"
+    "typescript": "5.2.2"
   }
 }

--- a/examples/typescript-nodejs/package-lock.json
+++ b/examples/typescript-nodejs/package-lock.json
@@ -12,7 +12,7 @@
         "@govuk-one-login/data-vocab": "^1.7.2"
       },
       "devDependencies": {
-        "typescript": "^5.2.2"
+        "typescript": "5.2.2"
       }
     },
     "node_modules/@govuk-one-login/data-vocab": {
@@ -25,6 +25,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/examples/typescript-nodejs/package.json
+++ b/examples/typescript-nodejs/package.json
@@ -14,6 +14,6 @@
     "@govuk-one-login/data-vocab": "^1.7.2"
   },
   "devDependencies": {
-    "typescript": "^5.2.2"
+    "typescript": "5.2.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.9.3",
       "license": "ISC",
       "devDependencies": {
-        "eslint-config-airbnb-base": "^14.2.1",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-jest": "^24.7.0",
-        "typescript": "^5.5.3",
-        "webpack": "^5.76.0",
-        "webpack-cli": "^5.0.1"
+        "eslint-config-airbnb-base": "14.2.1",
+        "eslint-plugin-import": "2.26.0",
+        "eslint-plugin-jest": "24.7.0",
+        "typescript": "5.5.3",
+        "webpack": "5.76.0",
+        "webpack-cli": "5.0.1"
       }
     },
     "mkdocs-govuk": {
@@ -1180,6 +1180,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
       "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
@@ -1243,6 +1244,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -1297,6 +1299,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
       "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       },
@@ -3709,6 +3712,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3792,6 +3796,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
       "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -3839,6 +3844,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
       "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "version": "1.9.3",
   "devDependencies": {
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^24.7.0",
-    "typescript": "^5.5.3",
-    "webpack": "^5.76.0",
-    "webpack-cli": "^5.0.1"
+    "eslint-config-airbnb-base": "14.2.1",
+    "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-jest": "24.7.0",
+    "typescript": "5.5.3",
+    "webpack": "5.76.0",
+    "webpack-cli": "5.0.1"
   },
   "repository": {
     "type": "git",

--- a/scripts/prep_release.sh
+++ b/scripts/prep_release.sh
@@ -20,8 +20,8 @@ function update_root_project(){
 
   npm version "$RELEASE_TYPE" --git-tag-version=false
 
-  # update lockfile etc.
-  npm install
+  # install dependencies
+  npm ci
 }
 
 #
@@ -32,8 +32,8 @@ function update_ts_generator() {
 
   npm version "$1"
 
-  # update lockfile etc.
-  npm install
+  # install dependencies
+  npm ci
 }
 
 #


### PR DESCRIPTION
In the interest of security and due to recent issues such as the Shai Hulud NPM supply chain incident:
* Pinned all NPM dependencies to specific versions
* Updated code to use `npm ci` instead of `npm install` so that transitive dependencies are not automatically upgraded to versions later than expected.

Although in some cases this now means that earlier versions of dependencies are now being used these should be addressed through Dependabot Pull Requests rather than automatically being pulled as a transitive dependency.