### PR TITLE
BAU: Grouped junit dependabots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,11 @@ updates:
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: '-'
+    groups:
+      junit-dependencies:
+        patterns:
+          - org.junit.jupiter*
+          - org.junit*
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## What

Updated dependabot configuration to group junit dependencies together.

## Why

Several of the junit dependabots are interrelated to one another and must be upgraded alongside other junit changes. This will also reduce the number of PRs down to one for junit changes rather than multiple.

## Testing

None. Dependabot configuration.
