### PR TITLE
SPT-1909: Add packages `write` permission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Publish Node ts-types package
@@ -68,6 +69,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
     environment: npmjs-publishing
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What

Add the packages `write` permssion to the TS publish steps, this was inadvertently missed from the previous PR.

## Why

The legacy publish to GitHub Packages step is failing due to the missing permission.

## Related PRs

#213 