### PR TITLE
SPT-1883: Remove use of Artifactory for Java dependencies

### DIFF
--- a/code-generators/java-types/schema-artefacts/build.gradle
+++ b/code-generators/java-types/schema-artefacts/build.gradle
@@ -4,11 +4,7 @@ plugins {
 }
 
 repositories {
-    repositories {
-        maven {
-            url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
-        }
-    }
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
## What

Reconfigure the Gradle build to pull direct Maven Central and other required Maven repositories rather than via Artifactory.

## Why

Our JFrog Artifactory instance is being shutdown at the end of the month as not really being used.