### PR TITLE
SPT-1936: Added IdentityAuthorisationRequest

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ nav:
               v1/classes/IdentityAssertionCredentialClass.md
           - IdentityAssertionCredentialJWTClass: 
               v1/classes/IdentityAssertionCredentialJWTClass.md
+          - IdentityAuthorisationRequestClass:
+              v1/classes/IdentityAuthorisationRequestClass.md
           - IdentityCheckClass: v1/classes/IdentityCheckClass.md
           - IdentityCheckCredentialClass: 
               v1/classes/IdentityCheckCredentialClass.md

--- a/scripts/generate_json_schemas.sh
+++ b/scripts/generate_json_schemas.sh
@@ -23,6 +23,7 @@ LINKML_ITEMS=(
   "identityCheckCredential.yaml,IdentityCheckCredentialClass,IdentityCheckCredential.json"
   "credentials.yaml,IdentityCheckCredentialJWTClass,IdentityCheckCredentialJWT.json"
   "credentials.yaml,InheritedIdentityJWTClass,InheritedIdentityJWT.json"
+  "credentials.yaml,IdentityAuthorisationRequestClass,IdentityAuthorisationRequest.json"
   "credentials.yaml,IssuerAuthorizationRequestClass,IssuerAuthorizationRequest.json"
   "name.yaml,NameClass,Name.json"
   "credentials.yaml,OpenIDConnectAuthenticationRequestClass,OpenIDConnectAuthenticationRequest.json"

--- a/v1/linkml-schemas/credentials.yaml
+++ b/v1/linkml-schemas/credentials.yaml
@@ -55,6 +55,19 @@ classes:
     see_also:
       - ../json-schemas/OpenIDConnectAuthenticationRequest.json
 
+  IdentityAuthorisationRequestClass:
+    is_a: AuthorizationRequestClass
+    description: |
+      An Identity Authorization Request that provides shared claims and other user/session data.
+
+      JSON schema: [IdentityAuthorisationRequest.json](../json-schemas/IdentityAuthorisationRequest.json)
+    slots:
+      - govuk_signin_journey_id
+      - vtr
+      - claims
+    see_also:
+      - ../json-schemas/IdentityAuthorisationRequest.json
+
   IssuerAuthorizationRequestClass:
     is_a: AuthorizationRequestClass
     description: |


### PR DESCRIPTION
## What

Added the `IdentityAuthorisationRequest` type which will be used for authorization requests for the Stored Identity Service. See https://govukverify.atlassian.net/wiki/spaces/SISS/pages/6523322370/The+Orch+to+SIS+JAR#Orchestration-%E2%86%92-IPV-Core

## Why

This is required by the Stored Identity Service to enable orchestration to safely authorise with the service.

## Testing

Compiled site and checked that documentation was being created.

## Related PRs

* https://github.com/govuk-one-login/ipv-reuse-service-stubs/pull/340